### PR TITLE
Ignore OpenTagNotFoundError errors from htmlmin

### DIFF
--- a/flask_htmlmin.py
+++ b/flask_htmlmin.py
@@ -1,4 +1,6 @@
+import logging
 from htmlmin import Minifier
+from htmlmin.parser import OpenTagNotFoundError
 
 __author__ = 'Hamid FzM'
 
@@ -31,9 +33,13 @@ class HTMLMIN(object):
         """
         if response.content_type == u'text/html; charset=utf-8':
             response.direct_passthrough = False
-            response.set_data(
-                self.html_minify.minify(response.get_data(as_text=True))
-            )
+            data = response.get_data(as_text=True)
+            try:
+                minified = self.html_minify.minify(data)
+            except OpenTagNotFoundError:
+                minified = data
+                logging.error('Could not minify data: OpenTagNotFoundError')
+            response.set_data(minified)
 
             return response
         return response


### PR DESCRIPTION
htmlmin raises OpenTagNotFoundError in some cases (origin unclear).
Catch the exception and pass the input through un-minified.

Works around #10, mankyd/htmlmin#46.