### PR TITLE
Stop using pytest-runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,18 +8,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: python setup.py install
+        run: |
+          pip install pipenv
+          pipenv install --python ${{ matrix.python-version }} --dev
 
       - name: Lint with flake8
         run: |
@@ -28,13 +30,8 @@ jobs:
           flake8 . --count --exit-zero --statistics
 
       - name: Test with pytest
-        run: python setup.py test
-
-      - name: Generate coverage
         run: |
-          pip install coverage
-          coverage run --source=flask_htmlmin setup.py test
-          coverage xml
+          pipenv run pytest --cov=flask_htmlmin --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 pytest = "*"
+pytest-cov = "*"
 twine = "*"
 wheel = "*"
 flake8 = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ verify_ssl = true
 
 [dev-packages]
 pytest = "*"
-pytest-runner = "*"
 twine = "*"
 wheel = "*"
 flake8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -397,14 +397,6 @@
             "index": "pypi",
             "version": "==5.4.1"
         },
-        "pytest-runner": {
-            "hashes": [
-                "sha256:5534b08b133ef9a5e2c22c7886a8f8508c95bb0b0bdc6cc13214f269c3c70d51",
-                "sha256:96c7e73ead7b93e388c5d614770d2bae6526efd997757d3543fe17b557a0942b"
-            ],
-            "index": "pypi",
-            "version": "==5.2"
-        },
         "readme-renderer": {
             "hashes": [
                 "sha256:63b4075c6698fcfa78e584930f07f39e05d46f3ec97f65006e430b595ca6348c",

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,4 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Text Processing :: Markup :: HTML',
     ],
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest']
 )


### PR DESCRIPTION
setup_requires and tests_requires are firmly deprecated by setuptools
upstream, and pytest-runner similarly, since it makes use of
functionality that setuptools would like to remove. Stop setting
{setup,test}_requires in setup.py, and remove pytest-runner from
Pipfile.

Fixes #29