### PR TITLE
Fix documentation error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app = Flask(__name__)
 app.config['MINIFY_HTML'] = True
 
 htmlmin = HTMLMIN(app)
-# or you can use HTMLMIN.init_app(app)
+# or you can use HTMLMIN().init_app(app)
 # pass additional parameters to htmlmin
 # HTMLMIN(app, **kwargs)
 # example:


### PR DESCRIPTION
`HTMLMIN.init_app(app)` doesn’t work because it’s an instance method, not a class one.